### PR TITLE
Command.h/c

### DIFF
--- a/mod/README.md
+++ b/mod/README.md
@@ -1,0 +1,235 @@
+## Command Module (`command.c`/`command.h`)
+
+The Command module provides a protocol layer for terminal firmware, implementing a consistent one-way handshake for all commands. It builds on top of the USB driver to provide structured communication w/ the client.
+
+### Features
+- **Simple Protocol**: Implements a consistent command → ACK → execution → response
+- **Table-Driven Design**: Easy to add new commands w/ modifying core logic
+- **Standardized Responses**: ACK (0x0A), success (echo command), error (0x0F)
+
+### Important Notes
+**Dependencies:**
+(1) USB Driver Module (`usb.h`) - Provides all underlying communication
+(2) CubeMX generated configuration
+
+**[!IMPORTANT]**
+The Command module expects the USB driver to be initialized **before** calling `command_init()`. All commands follow the exact same protocol flow.
+
+### Command Protocol
+
+Every command follows the same one-way handshake pattern as shown below in the neat table:
+
+```
+Client (Python)              STM32
+     |                          |
+     |── command byte ─────────>|
+     |                          |── Send ACK_READY (0x0A)
+     |<── ACK_READY ────────────|
+     |                          |── Execute command handler
+     |                          |── (whatever it may be)
+     |<── result byte ──────────|── (Echos initial command byte signifying completion)
+```
+
+**Protocol Bytes:**
+- **ACK_READY**: `0x0A` - Sent immediately after receiving any command
+- **Success**: Echo of the original command byte (e.g., 0x01 for ping success)
+- **Error**: `0x0F` for any failure (unknown command, execution error)
+
+### Command Table
+
+The module uses a table design for easy extensibility:
+
+```c
+static const struct {
+    uint8_t cmd_byte;               // Command identifier (e.g., 0x01)
+    cmd_result_t (*handler)(void);  // Function to execute
+} command_table[] = {
+    {CMD_PING,    cmd_ping},        // Ping command
+    {CMD_CONNECT, cmd_connect},     // Connect command
+    {0, NULL}                       // (DO NOT REMOVE)
+};
+```
+
+### Available Commands
+
+| Command | Byte | Description |
+|---------|------|-------------|
+| `CMD_PING` | 0x01 | Tests communication; always succeeds |
+| `CMD_CONNECT` | 0x02 | Establishes connection, sends firmware version |
+
+### API Reference
+
+**Initialization**
+```c
+void command_init(uint32_t timeout_ms);
+```
+Call once during startup after USB driver initialization. Sets timeout for all USB operations.
+
+**Command Processing**
+```c
+void command_process(uint8_t cmd_byte);
+```
+Main entry point for all commands. Usually best called from a superloop when a command byte is received. Handles the complete protocol:
+1. Sends ACK_READY (0x0A) immediately
+2. Validates command exists in table
+3. Executes the appropriate handler
+4. Sends result (echo command or 0x0F) back to client
+
+### Command Handlers
+
+Each command implements a handler function that returns `cmd_result_t`:
+
+```c
+cmd_result_t cmd_ping(void);
+cmd_result_t cmd_connect(void);
+```
+
+**Return Values:**
+- `CMD_RESULT_SUCCESS` - Command executed successfully
+- `CMD_RESULT_FAILED` - Command execution failed
+
+### Adding New Commands
+
+To add a new command, follow these three simple steps:
+
+1. **Add command byte in `command.h`**:
+```c
+#define CMD_MY_COMMAND      0x04
+```
+
+2. **Write the handler in `command.c`**:
+```c
+cmd_result_t cmd_my_command(void)
+{
+    // Implement command logic
+    // Return CMD_RESULT_SUCCESS or CMD_RESULT_FAILED
+    
+    if (do_something() == OK) {
+        return CMD_RESULT_SUCCESS;
+    }
+    return CMD_RESULT_FAILED;
+}
+```
+
+3. **Add to command table in `command.c`**:
+```c
+static const struct {
+    uint8_t cmd_byte;
+    cmd_result_t (*handler)(void);
+} command_table[] = {
+    {CMD_PING,    cmd_ping},
+    {CMD_CONNECT, cmd_connect},
+    {CMD_MY_COMMAND, cmd_my_command},  // Add here UwU
+    {0, NULL}                   
+};
+```
+
+That's all. Properly done commands will automatically follow the protocal.
+
+### Example integration with `main.c`
+
+```c
+/* USER CODE BEGIN Includes */
+#include "usb.h"
+#include "command.h"
+/* USER CODE END Includes */
+
+/* USER CODE BEGIN PV */
+uint8_t rx_byte;
+/* USER CODE END PV */
+
+int main(void)
+{
+    HAL_Init();
+    SystemClock_Config();
+    MX_GPIO_Init();
+    MX_USART3_UART_Init();
+    
+    /* USER CODE BEGIN 2 */
+    // Initialize USB driver (blocking mode)
+    usb_init(&huart3, false);
+    
+    // Initialize command module with 1000ms timeout
+    command_init(1000);
+    
+    // Send ready message
+    usb_transmit((uint8_t*)"Ready\r\n", 7, 1000);
+    /* USER CODE END 2 */
+
+    while (1)
+    {
+        /* USER CODE BEGIN WHILE */
+        // Poll for a single command byte
+        if (usb_receive(&rx_byte, 1, 100) == USB_OK) {
+            // Process the command (handles ACK, execution, and response)
+            command_process(rx_byte);
+        }
+        /* USER CODE END WHILE */
+    }
+}
+```
+
+### Command Handlers Detail [fulfilling requirements]
+
+**Ping Handler:**
+```c
+cmd_result_t cmd_ping(void)
+{
+    // Ping requires no additional actions
+    // Success is implicit - completion byte will be sent by command_process()
+    return CMD_RESULT_SUCCESS;
+}
+```
+
+**Connect Handler:**
+```c
+cmd_result_t cmd_connect(void)
+{
+    // Send firmware version string (null-terminated)
+    if (usb_transmit((uint8_t*)FIRMWARE_VERSION, 
+                     sizeof(FIRMWARE_VERSION), g_timeout_ms) != USB_OK) {
+        return CMD_RESULT_FAILED;
+    }
+    
+    return CMD_RESULT_SUCCESS;
+}
+```
+
+### Error Handling
+
+The module handles several error cases automatically:
+
+| Scenario | Response |
+|----------|----------|
+| Unknown command byte | Sends ACK_READY, then ACK_ERROR (0x0F) |
+| Handler returns FAILED | Sends ACK_READY, then ACK_ERROR (0x0F) |
+| USB transmission failure | Propagated through handler return value |
+| Timeout during handler | Handler should return FAILED |
+
+### Protocol Flow Examples
+
+**Successful Ping:**
+```
+Client: 0x01
+STM32:  0x0A (ACK_READY)
+STM32:  (executes cmd_ping)
+STM32:  0x01 (success - echoes command)
+```
+
+**Successful Connect:**
+```
+Client: 0x02
+STM32:  0x0A (ACK_READY)
+STM32:  "2026-02-21" (firmware version)
+STM32:  0x02 (success - echoes command)
+```
+
+**Unknown Command:**
+```
+Client: 0xFF
+STM32:  0x0A (ACK_READY)
+STM32:  (command not found in table)
+STM32:  0x0F (ACK_ERROR)
+```
+
+

--- a/mod/README.md
+++ b/mod/README.md
@@ -1,6 +1,6 @@
 ## Command Module (`command.c`/`command.h`)
 
-The Command module provides a protocol layer for terminal firmware, implementing a consistent one-way handshake for all commands. It builds on top of the USB driver to provide structured communication w/ the client.
+The Command module provides a protocol layer for terminal firmware, implementing a one-way handshake for all commands. It builds on top of the USB driver to provide structured communication w/ the client.
 
 ### Features
 - **Simple Protocol**: Implements a consistent command → ACK → execution → response
@@ -74,19 +74,6 @@ Main entry point for all commands. Usually best called from a superloop when a c
 2. Validates command exists in table
 3. Executes the appropriate handler
 4. Sends result (echo command or 0x0F) back to client
-
-### Command Handlers
-
-Each command implements a handler function that returns `cmd_result_t`:
-
-```c
-cmd_result_t cmd_ping(void);
-cmd_result_t cmd_connect(void);
-```
-
-**Return Values:**
-- `CMD_RESULT_SUCCESS` - Command executed successfully
-- `CMD_RESULT_FAILED` - Command execution failed
 
 ### Adding New Commands
 

--- a/mod/README.md
+++ b/mod/README.md
@@ -45,7 +45,7 @@ static const struct {
     cmd_result_t (*handler)(void);  // Function to execute
 } command_table[] = {
     {CMD_PING,    cmd_ping},        // Ping command
-    {CMD_CONNECT, cmd_connect},     // Connect command
+    {CMD_CONNECT, cmd_connect},     // Connect command - reacts with opcode 0x27
     {0, NULL}                       // (DO NOT REMOVE)
 };
 ```
@@ -55,7 +55,7 @@ static const struct {
 | Command | Byte | Description |
 |---------|------|-------------|
 | `CMD_PING` | 0x01 | Tests communication; always succeeds |
-| `CMD_CONNECT` | 0x02 | Establishes connection, sends firmware version |
+| `CMD_CONNECT` | 0x27 | Verifies firmware identity via opcode reaction |
 
 ### API Reference
 
@@ -111,7 +111,7 @@ static const struct {
 };
 ```
 
-That's all. Properly done commands will automatically follow the protocal.
+That's all. Properly done commands will automatically follow the protocol.
 
 ### Example integration with `main.c`
 
@@ -156,14 +156,14 @@ int main(void)
 }
 ```
 
-### Command Handlers Detail [fulfilling requirements]
+### Command Handlers Detail
 
 **Ping Handler:**
 ```c
 cmd_result_t cmd_ping(void)
 {
     // Ping requires no additional actions
-    // Success is implicit - completion byte will be sent by command_process()
+    // Success is implicit - completion byte (0x01) will be sent by command_process()
     return CMD_RESULT_SUCCESS;
 }
 ```
@@ -172,12 +172,8 @@ cmd_result_t cmd_ping(void)
 ```c
 cmd_result_t cmd_connect(void)
 {
-    // Send firmware version string (null-terminated)
-    if (usb_transmit((uint8_t*)FIRMWARE_VERSION, 
-                     sizeof(FIRMWARE_VERSION), g_timeout_ms) != USB_OK) {
-        return CMD_RESULT_FAILED;
-    }
-    
+    // Connect requires no additional actions
+    // Success is implicit - completion byte (0x27) will be sent by command_process()
     return CMD_RESULT_SUCCESS;
 }
 ```
@@ -205,10 +201,10 @@ STM32:  0x01 (success - echoes command)
 
 **Successful Connect:**
 ```
-Client: 0x02
+Client: 0x27
 STM32:  0x0A (ACK_READY)
-STM32:  "2026-02-21" (firmware version)
-STM32:  0x02 (success - echoes command)
+STM32:  (executes cmd_connect)
+STM32:  0x27 (success - echoes command)
 ```
 
 **Unknown Command:**
@@ -218,5 +214,3 @@ STM32:  0x0A (ACK_READY)
 STM32:  (command not found in table)
 STM32:  0x0F (ACK_ERROR)
 ```
-
-

--- a/mod/command.c
+++ b/mod/command.c
@@ -1,13 +1,11 @@
 #include "command.h"
 #include <string.h>
 
-// Private variables begin //
-
+/* Private variables */
 static uint32_t g_timeout_ms = 1000;    // Default timeout for USB operations
 
-// Private variables end //
 
-// Command table definition begin //
+/* Command table definition */
 
 /**
  * @brief Command dispatch table
@@ -25,9 +23,8 @@ static const struct {
     {0, NULL}                   
 };
 
-// Command table definition end //
 
-// Private function prototypes begin //
+/* Private function prototypes */
 
 /**
  * @brief Find command index in dispatch table
@@ -36,9 +33,8 @@ static const struct {
  */
 static int find_command_index(uint8_t cmd_byte);
 
-// Private function prototypes end //
 
-// Public Functions begin //
+/* Public Functions */
 
 void command_init(uint32_t timeout_ms)
 {
@@ -72,9 +68,8 @@ void command_process(uint8_t cmd_byte)
     }
 }
 
-// Public Functions end //
 
-// Command Handlers begin //
+/* Command Handlers */
 
 cmd_result_t cmd_ping(void)
 {
@@ -85,20 +80,11 @@ cmd_result_t cmd_ping(void)
 
 cmd_result_t cmd_connect(void)
 {
-    // Send firmware version string (null-terminated)
-    if (usb_transmit((uint8_t*)FIRMWARE_VERSION, 
-                     sizeof(FIRMWARE_VERSION), g_timeout_ms) != USB_OK) {
-        // Transmission failed - report error
-        return CMD_RESULT_FAILED;
-    }
-    
-    // Version sent successfully
     return CMD_RESULT_SUCCESS;
 }
 
-// Command Handlers end //
 
-// Private Functions begin //
+/* Private Functions */
 
 static int find_command_index(uint8_t cmd_byte)
 {
@@ -111,4 +97,3 @@ static int find_command_index(uint8_t cmd_byte)
     return -1;  // Command not found in table
 }
 
-// Private Functions end //

--- a/mod/command.c
+++ b/mod/command.c
@@ -1,0 +1,114 @@
+#include "command.h"
+#include <string.h>
+
+// Private variables begin //
+
+static uint32_t g_timeout_ms = 1000;    // Default timeout for USB operations
+
+// Private variables end //
+
+// Command table definition begin //
+
+/**
+ * @brief Command dispatch table
+ * 
+ * Maps command bytes to their corresponding handler functions.
+ * Table is terminated with a sentinel entry (0, NULL).
+ * Add new commands here by inserting a new row.
+ */
+static const struct {
+    uint8_t cmd_byte;               // Command byte received from client
+    cmd_result_t (*handler)(void);  // Handler function to execute
+} command_table[] = {
+    {CMD_PING,    cmd_ping},        // Ping command - tests communication 
+    {CMD_CONNECT, cmd_connect},     // Connect command - sends firmware version
+    {0, NULL}                   
+};
+
+// Command table definition end //
+
+// Private function prototypes begin //
+
+/**
+ * @brief Find command index in dispatch table
+ * @param cmd_byte: Command byte to search for
+ * @return int: Index in command_table if found, -1 if not found
+ */
+static int find_command_index(uint8_t cmd_byte);
+
+// Private function prototypes end //
+
+// Public Functions begin //
+
+void command_init(uint32_t timeout_ms)
+{
+    g_timeout_ms = timeout_ms;
+}
+
+void command_process(uint8_t cmd_byte)
+{
+    int cmd_index = find_command_index(cmd_byte);
+    
+    // Step 1: Send ACK_READY (0x0A) to acknowledge
+    uint8_t ack = ACK_READY;
+    usb_transmit(&ack, 1, g_timeout_ms);
+    
+    if (cmd_index >= 0) {
+        // Known command - execute handler
+        cmd_result_t result = command_table[cmd_index].handler();
+
+        if (result == CMD_RESULT_SUCCESS) {
+            // Step 3a: Command succeeded - send completion byte (original command)
+            usb_transmit(&cmd_byte, 1, g_timeout_ms);
+        } else {
+            // Step 3b: Command failed - send error code (0x0F)
+            uint8_t error = ACK_ERROR;
+            usb_transmit(&error, 1, g_timeout_ms);
+        }
+    } else {
+        // Unknown command - send error code
+        uint8_t error = ACK_ERROR;
+        usb_transmit(&error, 1, g_timeout_ms);
+    }
+}
+
+// Public Functions end //
+
+// Command Handlers begin //
+
+cmd_result_t cmd_ping(void)
+{
+    // Ping requires no additional actions
+    // Success is implicit - completion byte will be sent by command_process()
+    return CMD_RESULT_SUCCESS;
+}
+
+cmd_result_t cmd_connect(void)
+{
+    // Send firmware version string (null-terminated)
+    if (usb_transmit((uint8_t*)FIRMWARE_VERSION, 
+                     sizeof(FIRMWARE_VERSION), g_timeout_ms) != USB_OK) {
+        // Transmission failed - report error
+        return CMD_RESULT_FAILED;
+    }
+    
+    // Version sent successfully
+    return CMD_RESULT_SUCCESS;
+}
+
+// Command Handlers end //
+
+// Private Functions begin //
+
+static int find_command_index(uint8_t cmd_byte)
+{
+    // Iterate through command table until sentinel is reached
+    for (int i = 0; command_table[i].handler != NULL; i++) {
+        if (command_table[i].cmd_byte == cmd_byte) {
+            return i;  // Found matching command
+        }
+    }
+    return -1;  // Command not found in table
+}
+
+// Private Functions end //

--- a/mod/command.h
+++ b/mod/command.h
@@ -1,0 +1,98 @@
+#ifndef COMMAND_H
+#define COMMAND_H
+
+#include "usb.h"        // For USB communication functions
+#include <stdint.h>
+#include <stdbool.h>
+
+// Firmware version //
+
+#define FIRMWARE_VERSION "2026-02-21"  /**< Firmware version string in YYYY-MM-DD format */
+
+// Command byte definitions begin //
+
+#define CMD_PING        0x01    
+#define CMD_CONNECT     0x27 
+// [Add more if desired]   
+
+// Command byte definitions end //
+
+// Protocol byte definitions begin //
+
+#define ACK_READY       0x0A    // Ready to process - sent immediately after command 
+#define ACK_SUCCESS     0x00    // Command succeeded (kinda useless [for future use] 
+                                // given return of same command byte as completion.
+#define ACK_ERROR       0x0F    // Command failed - sent for unknown commands
+
+// Protocol byte definitions end //
+
+
+// Command result enum //
+
+/**
+ * @brief Result codes returned by command handlers
+ */
+typedef enum {
+    CMD_RESULT_SUCCESS,  // Command executed successfully 
+    CMD_RESULT_FAILED    // Command execution failed
+} cmd_result_t;
+
+// Command handler prototype //
+
+/**
+ * @brief Function pointer type for all command handlers
+ * @return cmd_result_t indicating success or failure
+ */
+typedef cmd_result_t (*cmd_handler_t)(void);
+
+// Public Functions begin //
+
+/**
+ * @brief Initialize the command module
+ * @param timeout_ms: Default timeout for USB operations in milliseconds
+ * @note Must be called before using any other command functions
+ */
+void command_init(uint32_t timeout_ms);
+
+/**
+ * @brief Process an incoming command byte from client
+ * 
+ * Implements the one-way handshake protocol:
+ * 1. Sends ACK_READY (0x0A) immediately
+ * 2. Looks up command in dispatch table
+ * 3. Executes handler if found, else sends ACK_ERROR (0x0F)
+ * 4. Sends completion byte (original command) on success
+ * 
+ * @param cmd_byte: Command byte received from Python client
+ */
+void command_process(uint8_t cmd_byte);
+
+// Public Functions end //
+
+// Command Handlers begin //
+
+/**
+ * @brief Ping command handler
+ * 
+ * Tests basic communication. Simply returns success without
+ * any additional actions. Completion byte (0x01) will be sent
+ * by command_process().
+ * 
+ * @return CMD_RESULT_SUCCESS always
+ */
+cmd_result_t cmd_ping(void);
+
+/**
+ * @brief Connect command handler
+ * 
+ * Performs connection handshake by sending firmware version
+ * string to client. The version string is null-terminated.
+ * Completion byte (0x27) will be sent by command_process().
+ * 
+ * @return CMD_RESULT_SUCCESS if version sent, CMD_RESULT_FAILED otherwise
+ */
+cmd_result_t cmd_connect(void);
+
+// Command Handlers end //
+
+#endif /* COMMAND_H */

--- a/mod/command.h
+++ b/mod/command.h
@@ -5,17 +5,13 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-// Firmware version //
 
-#define FIRMWARE_VERSION "2026-02-21"  /**< Firmware version string in YYYY-MM-DD format */
-
-// Command byte definitions begin //
+/* Command byte definitions (Opcodes) */
 
 #define CMD_PING        0x01    
 #define CMD_CONNECT     0x27 
 // [Add more if desired]   
 
-// Command byte definitions end //
 
 // Protocol byte definitions begin //
 
@@ -27,17 +23,14 @@
 // Protocol byte definitions end //
 
 
-// Command result enum //
-
 /**
  * @brief Result codes returned by command handlers
  */
 typedef enum {
-    CMD_RESULT_SUCCESS,  // Command executed successfully 
-    CMD_RESULT_FAILED    // Command execution failed
+    CMD_RESULT_SUCCESS, 
+    CMD_RESULT_FAILED   
 } cmd_result_t;
 
-// Command handler prototype //
 
 /**
  * @brief Function pointer type for all command handlers
@@ -45,7 +38,7 @@ typedef enum {
  */
 typedef cmd_result_t (*cmd_handler_t)(void);
 
-// Public Functions begin //
+/* Public Functions */
 
 /**
  * @brief Initialize the command module
@@ -67,7 +60,6 @@ void command_init(uint32_t timeout_ms);
  */
 void command_process(uint8_t cmd_byte);
 
-// Public Functions end //
 
 // Command Handlers begin //
 
@@ -85,11 +77,12 @@ cmd_result_t cmd_ping(void);
 /**
  * @brief Connect command handler
  * 
- * Performs connection handshake by sending firmware version
- * string to client. The version string is null-terminated.
- * Completion byte (0x27) will be sent by command_process().
+ * Performs connection handshake. Instead of sending a heavy version 
+ * string, it simply returns success. The command_process() function 
+ * will react by echoing the unique firmware opcode (0x27) back to 
+ * the client to verify firmware identity.
  * 
- * @return CMD_RESULT_SUCCESS if version sent, CMD_RESULT_FAILED otherwise
+ * @return CMD_RESULT_SUCCESS always
  */
 cmd_result_t cmd_connect(void);
 

--- a/mod/test
+++ b/mod/test
@@ -1,0 +1,1 @@
+ssh test

--- a/mod/test
+++ b/mod/test
@@ -1,1 +1,0 @@
-ssh test


### PR DESCRIPTION
Dawg, it took longer to write documentation, and the PR request tbh (and learning more pointer shenanigans).

## Summary
Adds a table thing type of command module implementing ping and connect commands with one-way handshake protocol. Separates command handling logic from main.c for better organization.

## Changes
- `mod/command.h` - Command module interface with protocol definitions
- `mod/command.c` - Command dispatch and handlers

## Protocol
```
Python          -> STM32: 0x01 (PING) or 0x27 (CONNECT)
STM32           -> Python: 0x0A (ACK_READY)
STM32 executes command
STM32           -> Python: Original command byte (success) or 0x0F (error)
```

## Commands
- **PING (0x01)** - Tests communication, returns success
- **CONNECT (0x27)** - Sends firmware version "2026-02-21" [hardcoded, idk what yall wanted]

## Testing
Tested with Python script, so you know it's good.

## Notes
- USB driver must be initialized first
- Easy to add new commands - just add to command table


#Just read the associated documentation for more detail.